### PR TITLE
Make checked a notify property

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -108,6 +108,7 @@ Styling a checkbox:
         type: Boolean,
         value: false,
         reflectToAttribute: true,
+        notify: true,
         observer: '_checkedChanged'
       },
 


### PR DESCRIPTION
As it stands, you have to bind with a custom event:

    <paper-checkbox checked="{{myVal::iron-change}}"></paper-checkbox>

I understand having to do that with native elements, but this seems like it should work with just:

    <paper-checkbox checked="{{myVal}}"></paper-checkbox>