### PR TITLE
MockInteractions has moved to a better place

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,11 +24,11 @@
     "web-component-tester": "Polymer/web-component-tester#^2.2.3",
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.8.0",
     "test-fixture": "PolymerElements/test-fixture#^0.8.0",
-    "core-focusable": "polymer/core-focusable#0.8-preview"
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^0.8.0"
   },
   "dependencies": {
     "polymer": "polymer/polymer#v0.8.0-rc.6",
-    "paper-ripple": "Polymer/paper-ripple#0.8-preview",
+    "paper-ripple": "PolymerElements/paper-ripple#^0.8.0",
     "paper-styles": "PolymerElements/paper-styles#^0.8.0"
   }
 }

--- a/index.html
+++ b/index.html
@@ -21,16 +21,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../polymer/polymer.html">
     <link rel="import" href="../iron-doc-viewer/iron-doc-viewer.html">
 
-    <style>
-      body {
-        margin: 16px;
-      }
-    </style>
-
   </head>
   <body>
 
-    <iron-doc-viewer src="paper-checkbox.html"></iron-doc-viewer>
+    <iron-doc-viewer></iron-doc-viewer>
 
   </body>
 </html>

--- a/test/basic.html
+++ b/test/basic.html
@@ -16,7 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
-  <script src="../../core-focusable/test/test-helpers.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-checkbox.html">


### PR DESCRIPTION
From core-focusable to iron-test-helpers. I've also:
- cleaned up the `paper-ripple` deps in `bower.json`
- caught up with the updates in `iron-doc-viewer`