### PR TITLE
Clean up behaviour properties

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "web-component-tester": "Polymer/web-component-tester#^2.2.3",
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.8.0",
     "test-fixture": "PolymerElements/test-fixture#^0.8.0",
-    "iron-test-helpers": "PolymerElements/iron-test-helpers#^0.8.0"
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^0.8.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^0.8.0"
   },
   "dependencies": {
     "polymer": "polymer/polymer#v0.8.0-rc.7",

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="apple-mobile-web-app-capable" content="yes">
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../../paper-styles/layout.html">
+    <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
     <link rel="import" href="../paper-checkbox.html">
 
     <link rel="stylesheet" href="../../paper-styles/demo.css">

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -116,20 +116,21 @@ Styling a checkbox:
       },
 
       /**
-       * If true, the user cannot interact with this element.
+       * If true, the button toggles the active state with each tap or press
+       * of the spacebar.
        *
-       * @attribute disabled
+       * @attribute toggles
        * @type boolean
-       * @default false
+       * @default true
        */
-      disabled: {
-        type: Boolean
+      toggles: {
+        type: Boolean,
+        value: true,
+        reflectToAttribute: true
       }
     },
 
     ready: function() {
-      this.toggles = true;
-
       if (this.$.checkboxLabel.textContent == '') {
         this.$.checkboxLabel.hidden = true;
       } else {


### PR DESCRIPTION
Cleaned up the inherited behaviour properties and used `iron-flex-layout` in the demo.