### PR TITLE
fix theme colours

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -29,6 +29,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         --paper-checkbox-checked-color: var(--accent-color);
         --paper-checkbox-checked-ink-color: var(--accent-color);
+
+        --paper-checkbox-label-color: #009987;
       }
 
       .note {
@@ -44,6 +46,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
     <section>
       <div>
+        <paper-checkbox></paper-checkbox>
+        <paper-checkbox checked></paper-checkbox>
+        <paper-checkbox disabled></paper-checkbox>
+        <paper-checkbox disabled checked></paper-checkbox>
+
+        <br>
+
         <paper-checkbox><h4>Notifications</h4></paper-checkbox>
         <div class="note">Notify me about updates to apps or games that I've downloaded</div>
 

--- a/paper-checkbox.css
+++ b/paper-checkbox.css
@@ -38,6 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   width: 48px;
   height: 48px;
   color: var(--paper-checkbox-unchecked-ink-color);
+  opacity: 0.6;
 }
 
 :host #ink[checked] {
@@ -121,6 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   padding-left: 8px;
   white-space: normal;
   pointer-events: none;
+  color: var(--paper-checkbox-label-color);
 }
 
 #checkboxLabel[hidden] {
@@ -133,10 +135,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 :host([disabled]) #checkbox {
-  opacity: 0.33;
+  opacity: 0.5;
   border-color: var(--paper-checkbox-unchecked-color);
 }
 
 :host([disabled][checked]) #checkbox {
   background-color: var(--paper-checkbox-unchecked-color);
+  opacity: 0.5;
+}
+
+:host([disabled]) #checkboxLabel  {
+  opacity: 0.65;
 }

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -37,6 +37,9 @@ Styling a checkbox:
     /* Checked state colors. */
     --paper-checkbox-checked-color: #009688;
     --paper-checkbox-checked-ink-color: #009688;
+
+    /* Label color. */
+    --paper-checkbox-label-color: #009987;
   }
 </style>
 
@@ -50,6 +53,8 @@ Styling a checkbox:
 
     --paper-checkbox-checked-color: var(--default-primary-color);
     --paper-checkbox-checked-ink-color: var(--default-primary-color);
+
+    --paper-checkbox-label-color: var(--primary-text-color);
   }
 </style>
 
@@ -136,6 +141,9 @@ Styling a checkbox:
 
       // button-behavior hook
       _buttonStateChanged: function() {
+        if (this.disabled) {
+          return;
+        }
         this.checked = this.active;
       },
 


### PR DESCRIPTION
- makes colours more accessible (https://github.com/PolymerElements/paper-checkbox/issues/11)
- decreases the ripple opacity (https://github.com/PolymerElements/paper-checkbox/issues/15)
- disabled and checked checkboxes didn't work, and now they do
- added a custom property for the label colour

/cc @cdata 