### PR TITLE
add the checked behaviour

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,7 @@
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
+    "iron-checked-element-behavior": "PolymerElements/iron-checked-element-behavior#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"
   }
 }

--- a/paper-checkbox.css
+++ b/paper-checkbox.css
@@ -150,3 +150,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 :host([disabled]) #checkboxLabel  {
   opacity: 0.65;
 }
+
+/* invalid state */
+#checkbox.invalid:not(.checked) {
+  border-color: var(--paper-checkbox-error-color, --google-red-500);
+}

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -11,8 +11,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
-
+<link rel="import" href="../iron-checked-element-behavior/iron-checked-element-behavior.html">
 <!--
 
 `paper-checkbox` is a button that can be either checked or unchecked.  User
@@ -40,6 +41,7 @@ Custom property | Description | Default
 `--paper-checkbox-checked-ink-color` | Selected/focus ripple color when the input is checked | `--default-primary-color`
 `--paper-checkbox-checkmark-color` | Checkmark color | `white`
 `--paper-checkbox-label-color` | Label color | `--primary-text-color`
+`--paper-checkbox-error-color` | Checkbox color when invalid | `--google-red-500`
 
 @demo demo/index.html
 -->
@@ -51,7 +53,7 @@ Custom property | Description | Default
 
     <div id="checkboxContainer">
       <paper-ripple id="ink" class="circle" center checked$="[[checked]]"></paper-ripple>
-      <div id="checkbox" class$="[[_computeCheckboxClass(checked)]]">
+      <div id="checkbox" class$="[[_computeCheckboxClass(checked, invalid)]]">
         <div id="checkmark" class$="[[_computeCheckmarkClass(checked)]]"></div>
       </div>
     </div>
@@ -65,7 +67,8 @@ Custom property | Description | Default
       is: 'paper-checkbox',
 
       behaviors: [
-        Polymer.PaperInkyFocusBehavior
+        Polymer.PaperInkyFocusBehavior,
+        Polymer.IronCheckedElementBehavior
       ],
 
       hostAttributes: {
@@ -87,25 +90,8 @@ Custom property | Description | Default
          * @event iron-change
          */
 
-        /**
-         * Gets or sets the state, `true` is checked and `false` is unchecked.
-         */
-        checked: {
-          type: Boolean,
-          value: false,
-          reflectToAttribute: true,
-          notify: true,
-          observer: '_checkedChanged'
-        },
-
-        /**
-         * If true, the button toggles the active state with each tap or press
-         * of the spacebar.
-         */
-        toggles: {
-          type: Boolean,
-          value: true,
-          reflectToAttribute: true
+        ariaActiveAttribute: {
+          value: 'aria-checked'
         }
       },
 
@@ -141,24 +127,19 @@ Custom property | Description | Default
         }
       },
 
-      _checkedChanged: function(checked) {
-        this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
-        this.active = this.checked;
-        this.fire('iron-change');
-      },
-
-      _computeCheckboxClass: function(checked) {
+      _computeCheckboxClass: function(checked, invalid) {
+        var className = '';
         if (checked) {
-          return 'checked';
+          className += 'checked ';
         }
-        return '';
+        if (invalid) {
+          className += 'invalid';
+        }
+        return className;
       },
 
       _computeCheckmarkClass: function(checked) {
-        if (!checked) {
-          return 'hidden';
-        }
-        return '';
+        return checked ? '' : 'hidden';
       }
     })
   </script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -50,31 +50,51 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         c1 = fixture('NoLabel');
       });
 
-      test('check checkbox via click', function() {
+      test('check checkbox via click', function(done) {
         c1.addEventListener('click', function() {
           assert.isTrue(c1.getAttribute('aria-checked') == 'true');
           assert.isTrue(c1.checked);
+          done();
         });
         MockInteractions.tap(c1);
       });
 
-      test('toggle checkbox via click', function() {
+      test('toggle checkbox via click', function(done) {
         c1.checked = true;
         c1.addEventListener('click', function() {
           assert.isFalse(c1.getAttribute('aria-checked') != 'false');
           assert.isFalse(c1.checked);
+          done();
         });
         MockInteractions.tap(c1);
       });
 
-      test('disabled checkbox cannot be clicked', function() {
+      test('disabled checkbox cannot be clicked', function(done) {
         c1.disabled = true;
         c1.checked = true;
-        c1.addEventListener('click', function() {
+        MockInteractions.tap(c1);
+        setTimeout(function() {
           assert.isTrue(c1.getAttribute('aria-checked') == 'true');
           assert.isTrue(c1.checked);
-        });
-        MockInteractions.tap(c1);
+          done();
+        }, 1);
+      });
+
+      test('checkbox can be validated', function() {
+        c1.required = true;
+        assert.isFalse(c1.validate());
+
+        c1.checked = true;
+        assert.isTrue(c1.validate());
+      });
+
+      test('disabled checkbox is always valid', function() {
+        c1.disabled = true;
+        c1.required = true;
+        assert.isTrue(c1.validate());
+
+        c1.checked = true;
+        assert.isTrue(c1.validate());
       });
 
       test('checkbox label can be updated', function() {


### PR DESCRIPTION
Add the new `IronCheckedElementBehavior`, and actually allow this element to be used in a form (fixes #38)

Depends on (review top to bottom):
 - [x] ~~https://github.com/PolymerElements/iron-validatable-behavior/pull/12~~
 - [x] ~~https://github.com/PolymerElements/iron-form-element-behavior/pull/16~~
 - [x] ~~https://github.com/PolymerElements/iron-form/pull/37~~
 - [x] ~~https://github.com/PolymerElements/iron-checked-element-behavior/pull/1~~
 - [x] ~~https://github.com/PolymerElements/iron-checked-element-behavior/pull/2~~
 - [x] ~~https://github.com/PolymerElements/iron-form/pull/40~~

Since this has been alive for so long, it now also fixes #44
:skull: 

@cdata PTAL.