### PR TITLE
Ignore clicks to the paper-ripple.

### DIFF
--- a/paper-checkbox.css
+++ b/paper-checkbox.css
@@ -40,6 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   height: 48px;
   color: var(--paper-checkbox-unchecked-ink-color, --primary-text-color);
   opacity: 0.6;
+  pointer-events: none;
 }
 
 :host #ink[checked] {


### PR DESCRIPTION
The paper-ripple is larger than the checkbox, so it sometimes intercepted clicks meant for other elements.  Ignore clicks with CSS so they can reach the intended element.