### PR TITLE
fix aria label and dynamic creation

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -109,11 +109,14 @@ Custom property | Description | Default
         }
       },
 
-      ready: function() {
-        if (Polymer.dom(this).textContent == '') {
+      attached: function() {
+        var trimmedText = Polymer.dom(this).textContent.trim();
+        if (trimmedText === '') {
           this.$.checkboxLabel.hidden = true;
-        } else {
-          this.setAttribute('aria-label', Polymer.dom(this).textContent);
+        }
+        // Don't stomp over a user-set aria-label.
+        if (trimmedText !== '' && !this.getAttribute('aria-label')) {
+          this.setAttribute('aria-label', trimmedText);
         }
         this._isReady = true;
       },

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,6 +36,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="AriaLabel">
+    <template>
+      <paper-checkbox id="check3" aria-label="Batman">Robin</paper-checkbox>
+    </template>
+  </test-fixture>
+
   <script>
     suite('defaults', function() {
       var c1;
@@ -92,6 +98,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('checkbox with a label sets an aria label', function() {
         assert.isTrue(c2.getAttribute('aria-label') == "Batman");
+      });
+
+      test('checkbox respects the user set aria-label', function() {
+        var c = fixture('AriaLabel');
+        assert.isTrue(c.getAttribute('aria-label') == "Batman");
       });
     });
   </script>


### PR DESCRIPTION
- Fixes #32 -- `textContent` was a little misunderstood, and will contain any whitespace between the `>` and the `</paper-checkbox>` which means the line `textContent == ''` is very rarely true.
- Fixes the parallel bug to https://github.com/PolymerElements/paper-radio-button/issues/26, where dynamically creating checkboxes was broken. This is still broken, but not as much, and will be fixed again when we can listen to changes in `<content>` (which is the correct solution)

@cdata PTAL