### PR TITLE
add an option to manually force a label update

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -110,15 +110,25 @@ Custom property | Description | Default
       },
 
       attached: function() {
-        var trimmedText = Polymer.dom(this).textContent.trim();
-        if (trimmedText === '') {
-          this.$.checkboxLabel.hidden = true;
-        }
-        // Don't stomp over a user-set aria-label.
-        if (trimmedText !== '' && !this.getAttribute('aria-label')) {
-          this.setAttribute('aria-label', trimmedText);
-        }
         this._isReady = true;
+
+        // Don't stomp over a user-set aria-label.
+        if (!this.getAttribute('aria-label')) {
+          this.updateAriaLabel();
+        }
+      },
+
+
+      /**
+       * Update the checkbox aria-label. This is a temporary workaround not
+       * being able to observe changes in <content>
+       * (see: https://github.com/Polymer/polymer/issues/1773)
+       *
+       * Call this if you manually change the contents of the checkbox
+       * and want the aria-label to match the new contents.
+       */
+      updateAriaLabel: function() {
+        this.setAttribute('aria-label', Polymer.dom(this).textContent.trim());
       },
 
       // button-behavior hook

--- a/test/basic.html
+++ b/test/basic.html
@@ -76,6 +76,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
         MockInteractions.tap(c1);
       });
+
+      test('checkbox label can be updated', function() {
+        Polymer.dom(c1).textContent = 'Batman';
+        c1.updateAriaLabel();
+        assert.isTrue(c1.getAttribute('aria-label') == 'Batman');
+
+        Polymer.dom(c1).textContent = 'Robin';
+        c1.updateAriaLabel();
+        assert.isTrue(c1.getAttribute('aria-label') == 'Robin');
+      });
     });
 
     suite('a11y', function() {


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-checkbox/issues/49

While we're waiting on observing changes to `<content>`,  add an option to manually trigger an update. 

Also, removed hiding the label too because:
 - in the past the label-hiding-code was very likely never not getting called, because `textContent` was hardly ever actually `''`
 - this worked in our favour, since the `<content>` is probably updated after the checkboxes `ready()` (in any case it can't be guaranteed). So then it would magically appear when it was ready
- but since the `''` fix, the label is hid, an observer for `<content>` doesn't exist, so when the text does come in, the label stays hidden.

:bomb: :skull: :bomb: 

@cdata PTAL