### PR TITLE
create a var for #checkboxLabel display attribute

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -161,7 +161,7 @@ Custom property | Description | Default
       /* label */
       #checkboxLabel {
         position: relative;
-        display: inline-block;
+        display: var(--paper-checkbox-label-display, inline-block);
         vertical-align: middle;
         padding-left: 8px;
         white-space: normal;


### PR DESCRIPTION
This allows us to hide the label completely with display:none so that the 8px whitespace is gone. It's especially useful when centering a column of checkboxes.