### PR TITLE
simplify aria code

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -80,7 +80,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div>
         <h4>Color</h4>
         <div class="horizontal-section">
-          <paper-checkbox class="blue" checked>Oxygen</paper-checkbox>
+          <paper-checkbox class="blue" checked aria-label="Hurray for oxygen">Oxygen</paper-checkbox>
           <paper-checkbox class="red" checked>Carbon</paper-checkbox>
           <paper-checkbox class="orange" checked>Hydrogen</paper-checkbox>
           <paper-checkbox class="green" checked>Nitrogen</paper-checkbox>

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -245,23 +245,6 @@ Custom property | Description | Default
 
       attached: function() {
         this._isReady = true;
-
-        // Don't stomp over a user-set aria-label.
-        if (!this.getAttribute('aria-label')) {
-          this.updateAriaLabel();
-        }
-      },
-
-      /**
-       * Update the checkbox aria-label. This is a temporary workaround not
-       * being able to observe changes in <content>
-       * (see: https://github.com/Polymer/polymer/issues/1773)
-       *
-       * Call this if you manually change the contents of the checkbox
-       * and want the aria-label to match the new contents.
-       */
-      updateAriaLabel: function() {
-        this.setAttribute('aria-label', Polymer.dom(this).textContent.trim());
       },
 
       // button-behavior hook

--- a/test/basic.html
+++ b/test/basic.html
@@ -96,16 +96,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         c1.checked = true;
         assert.isTrue(c1.validate());
       });
-
-      test('checkbox label can be updated', function() {
-        Polymer.dom(c1).textContent = 'Batman';
-        c1.updateAriaLabel();
-        assert.isTrue(c1.getAttribute('aria-label') == 'Batman');
-
-        Polymer.dom(c1).textContent = 'Robin';
-        c1.updateAriaLabel();
-        assert.isTrue(c1.getAttribute('aria-label') == 'Robin');
-      });
     });
 
     suite('a11y', function() {
@@ -124,10 +114,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('checkbox with no label has no aria label', function() {
         assert.isTrue(!c1.getAttribute('aria-label'));
-      });
-
-      test('checkbox with a label sets an aria label', function() {
-        assert.isTrue(c2.getAttribute('aria-label') == "Batman");
       });
 
       test('checkbox respects the user set aria-label', function() {


### PR DESCRIPTION
I think we are trying to be too smart with the aria code, and we don't need to be. 

- by virtue of `textContent`, it gets read by VoiceOver readers by default, so we don't really need to mirror it to the aria-label. 
- on top of that, if the user doesn't want to read the `textContent` (because they want a custom text or their `textContent` is a giant chunk of text that needs to be tl; dr'ed), they would have to set the `aria-label` manually anyway, which this also allows.

I don't think this should change anything from the status quo, other than make the code less insane.

/cc @alice 

