### PR TITLE
Fixes #56

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -87,6 +87,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <paper-checkbox class="blue" checked>Calcium</paper-checkbox>
         </div>
       </div>
+      <div>
+        <h4>Noink</h4>
+        <div class="horizontal-section">
+          <paper-checkbox noink>Oxygen</paper-checkbox>
+          <paper-checkbox noink>Carbon</paper-checkbox>
+          <paper-checkbox checked noink>Hydrogen</paper-checkbox>
+          <paper-checkbox checked noink>Nitrogen</paper-checkbox>
+          <paper-checkbox checked noink>Calcium</paper-checkbox>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -12,7 +12,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-styles/color.html">
-<link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
 <link rel="import" href="../paper-behaviors/paper-checked-element-behavior.html">
 
 <!--
@@ -214,7 +213,6 @@ Custom property | Description | Default
       is: 'paper-checkbox',
 
       behaviors: [
-        Polymer.PaperInkyFocusBehavior,
         Polymer.PaperCheckedElementBehavior
       ],
 
@@ -243,8 +241,6 @@ Custom property | Description | Default
       },
 
       attached: function() {
-        this._isReady = true;
-
         // Don't stomp over a user-set aria-label.
         if (!this.getAttribute('aria-label')) {
           this.updateAriaLabel();
@@ -261,16 +257,6 @@ Custom property | Description | Default
        */
       updateAriaLabel: function() {
         this.setAttribute('aria-label', Polymer.dom(this).textContent.trim());
-      },
-
-      // button-behavior hook
-      _buttonStateChanged: function() {
-        if (this.disabled) {
-          return;
-        }
-        if (this._isReady) {
-          this.checked = this.active;
-        }
       },
 
       _computeCheckboxClass: function(checked, invalid) {

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
-<link rel="import" href="../iron-checked-element-behavior/iron-checked-element-behavior.html">
+<link rel="import" href="../paper-behaviors/paper-checked-element-behavior.html">
 
 <!--
 Material design: [Checkbox](https://www.google.com/design/spec/components/selection-controls.html#selection-controls-checkbox)
@@ -49,7 +49,7 @@ Custom property | Description | Default
 -->
 
 <dom-module id="paper-checkbox">
-  <template>
+  <template strip-whitespace>
     <style>
       :host {
         display: inline-block;
@@ -201,7 +201,6 @@ Custom property | Description | Default
     </style>
 
     <div id="checkboxContainer">
-      <paper-ripple id="ink" class="circle" center checked$="[[checked]]"></paper-ripple>
       <div id="checkbox" class$="[[_computeCheckboxClass(checked, invalid)]]">
         <div id="checkmark" class$="[[_computeCheckmarkClass(checked)]]"></div>
       </div>
@@ -216,7 +215,7 @@ Custom property | Description | Default
 
       behaviors: [
         Polymer.PaperInkyFocusBehavior,
-        Polymer.IronCheckedElementBehavior
+        Polymer.PaperCheckedElementBehavior
       ],
 
       hostAttributes: {
@@ -287,7 +286,14 @@ Custom property | Description | Default
 
       _computeCheckmarkClass: function(checked) {
         return checked ? '' : 'hidden';
+      },
+
+      // create ripple inside the checkboxContainer
+      _createRipple: function() {
+        this._rippleContainer = this.$.checkboxContainer;
+        return Polymer.PaperInkyFocusBehaviorImpl._createRipple.call(this);
       }
+
     });
   </script>
 </dom-module>


### PR DESCRIPTION
Fixes #56: Remove <paper-ripple> since PaperInkyFocusBehavior now manages this.

Should be merged after https://github.com/PolymerElements/paper-behaviors/pull/32.