### PR TITLE
be rtl friendly

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -42,6 +42,7 @@ Custom property | Description | Default
 `--paper-checkbox-checked-ink-color` | Selected/focus ripple color when the input is checked | `--default-primary-color`
 `--paper-checkbox-checkmark-color` | Checkmark color | `white`
 `--paper-checkbox-label-color` | Label color | `--primary-text-color`
+`--paper-checkbox-label-spacing` | Spacing between the label and the checkbox | `8px`
 `--paper-checkbox-error-color` | Checkbox color when invalid | `--google-red-500`
 
 @demo demo/index.html
@@ -75,7 +76,7 @@ Custom property | Description | Default
         background-color: var(--paper-checkbox-unchecked-background-color, transparent);
       }
 
-      :host #ink {
+      #ink {
         position: absolute;
         top: -15px;
         left: -15px;
@@ -86,11 +87,16 @@ Custom property | Description | Default
         pointer-events: none;
       }
 
-      :host #ink[checked] {
+      :host-context([dir="rtl"]) #ink {
+        right: -15px;
+        left: auto;
+      }
+
+      #ink[checked] {
         color: var(--paper-checkbox-checked-ink-color, --default-primary-color);
       }
 
-      :host #checkbox {
+      #checkbox {
         position: relative;
         box-sizing: border-box;
         height: 100%;
@@ -138,12 +144,12 @@ Custom property | Description | Default
         }
       }
 
-      :host #checkbox.checked {
+      #checkbox.checked {
         background-color: var(--paper-checkbox-checked-color, --default-primary-color);
         border-color: var(--paper-checkbox-checked-color, --default-primary-color);
       }
 
-      :host #checkmark {
+      #checkmark {
         -webkit-transform: rotate(45deg);
         transform: rotate(45deg);
         position: absolute;
@@ -164,10 +170,15 @@ Custom property | Description | Default
         position: relative;
         display: inline-block;
         vertical-align: middle;
-        padding-left: 8px;
+        padding-left: var(--paper-checkbox-label-spacing, 8px);
         white-space: normal;
         pointer-events: none;
         color: var(--paper-checkbox-label-color, --primary-text-color);
+      }
+
+      :host-context([dir="rtl"]) #checkboxLabel {
+        padding-right: var(--paper-checkbox-label-spacing, 8px);
+        padding-left: 0;
       }
 
       #checkboxLabel[hidden] {


### PR DESCRIPTION
:tada: Also:
- removed some useless `:host` that weren't needed. They were there from the early days, to get around a styling bug I believe
- added a custom property for the label spacing (originally in https://github.com/PolymerElements/paper-checkbox/pull/62)

As sanity checks, 
With `<html dir="rtl">`
<img width="843" alt="screen shot 2015-10-14 at 9 04 18 am" src="https://cloud.githubusercontent.com/assets/1369170/10489640/b1a5a5d4-7252-11e5-8f66-a19b12167430.png">

With setting `dir="rtl"` on the parent div:
<img width="271" alt="screen shot 2015-10-14 at 9 03 10 am" src="https://cloud.githubusercontent.com/assets/1369170/10489658/bd25b890-7252-11e5-95ca-b80cf48385ba.png">

With `<paper-checkbox dir="rtl">`
<img width="272" alt="screen shot 2015-10-14 at 9 04 37 am" src="https://cloud.githubusercontent.com/assets/1369170/10489653/b86c1218-7252-11e5-9e62-4595931838be.png">

