### PR TITLE
Enforces that the checkbox is square even if the label is longer than the available element space

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -70,6 +70,7 @@ Custom property | Description | Default
         position: relative;
         width: 18px;
         height: 18px;
+        min-width: 18px;
         vertical-align: middle;
         background-color: var(--paper-checkbox-unchecked-background-color, transparent);
       }


### PR DESCRIPTION
![checkbox-squeezed](https://cloud.githubusercontent.com/assets/9339055/11245343/949f7ca4-8e12-11e5-9eda-88a8e0ec96ba.png)

#78 Fixes#78