### PR TITLE
add a custom property to control the checkbox size

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -44,6 +44,7 @@ Custom property | Description | Default
 `--paper-checkbox-label-color` | Label color | `--primary-text-color`
 `--paper-checkbox-label-spacing` | Spacing between the label and the checkbox | `8px`
 `--paper-checkbox-error-color` | Checkbox color when invalid | `--google-red-500`
+`--paper-checkbox-size` | Size of the checkbox | `18px`
 
 @demo demo/index.html
 -->
@@ -55,6 +56,7 @@ Custom property | Description | Default
         display: inline-block;
         white-space: nowrap;
         cursor: pointer;
+        --calculated-paper-checkbox-size: var(--paper-checkbox-size, 18px);
       }
 
       :host(:focus) {
@@ -68,26 +70,29 @@ Custom property | Description | Default
       #checkboxContainer {
         display: inline-block;
         position: relative;
-        width: 18px;
-        height: 18px;
-        min-width: 18px;
+        width: var(--calculated-paper-checkbox-size);
+        height: var(--calculated-paper-checkbox-size);
+        min-width: var(--calculated-paper-checkbox-size);
         vertical-align: middle;
         background-color: var(--paper-checkbox-unchecked-background-color, transparent);
       }
 
       #ink {
         position: absolute;
-        top: -15px;
-        left: -15px;
-        width: 48px;
-        height: 48px;
+
+        /* Center the ripple in the checkbox by negative offsetting it by
+         * (inkWidth - rippleWidth) / 2 */
+        top: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
+        left: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
+        width: calc(2.66 * var(--calculated-paper-checkbox-size));
+        height: calc(2.66 * var(--calculated-paper-checkbox-size));
         color: var(--paper-checkbox-unchecked-ink-color, --primary-text-color);
         opacity: 0.6;
         pointer-events: none;
       }
 
       :host-context([dir="rtl"]) #ink {
-        right: -15px;
+        right: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
         left: auto;
       }
 
@@ -138,16 +143,21 @@ Custom property | Description | Default
 
       #checkmark {
         position: absolute;
-        width: 5px;
-        height: 10px;
+        width: 36%;
+        height: 70%;
         border-style: solid;
         border-top: none;
         border-left: none;
-        border-right-width: 2px;
-        border-bottom-width: 2px;
+        border-right-width: calc(2/15 * var(--calculated-paper-checkbox-size));
+        border-bottom-width: calc(2/15 * var(--calculated-paper-checkbox-size));
         border-color: var(--paper-checkbox-checkmark-color, white);
         transform-origin: 97% 86%;
         -webkit-transform-origin: 97% 86%;
+      }
+
+      :host-context([dir="rtl"]) #checkmark {
+        transform-origin: 50% 14%;
+        -webkit-transform-origin: 50% 14%;
       }
 
       /* label */

--- a/test/basic.html
+++ b/test/basic.html
@@ -19,6 +19,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../paper-checkbox.html">
 </head>
+<style is="custom-style">
+  paper-checkbox.giant {
+    --paper-checkbox-size: 50px;
+  }
+  paper-checkbox.tiny {
+    --paper-checkbox-size: 5px;
+  }
+</style>
 <body>
 
   <test-fixture id="NoLabel">
@@ -36,6 +44,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="AriaLabel">
     <template>
       <paper-checkbox id="check3" aria-label="Batman">Robin</paper-checkbox>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="WithDifferentSizes">
+    <template>
+      <paper-checkbox></paper-checkbox>
+      <paper-checkbox class="giant"></paper-checkbox>
+      <paper-checkbox class="tiny"></paper-checkbox>
     </template>
   </test-fixture>
 
@@ -92,6 +108,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         c1.checked = true;
         assert.isTrue(c1.validate());
+      });
+
+      test('checkbox can check sizes', function() {
+        var c2 = fixture('WithDifferentSizes');
+        var normal = c2[0].getBoundingClientRect();
+        var giant = c2[1].getBoundingClientRect();
+        var tiny = c2[2].getBoundingClientRect();
+
+        assert.isTrue(5 <= tiny.height < normal.height < giant.height <= 50);
+        assert.isTrue(5 <= tiny.width < normal.width < giant.width <= 50);
       });
     });
 


### PR DESCRIPTION
Oh boy! We have some dark magik math going on now, so that we can `--paper-checkbox-size` can finally be a thing. Fixes https://github.com/PolymerElements/paper-checkbox/issues/59

First, here's a gif that shows that the status quo looks pretty much the same. You'll notice the label jumps a bit, and that's because even if the label padding was set to 0, there was still an inherent padding, which I think was wrong, and has been fixed:
![checkbox](https://cloud.githubusercontent.com/assets/1369170/11490498/07ab71d8-978e-11e5-9a29-e575000c0f90.gif)

Here's a normal, tiny and giant checkbox:
<img width="149" alt="screen shot 2015-11-30 at 5 59 30 pm" src="https://cloud.githubusercontent.com/assets/1369170/11490507/11e93db0-978e-11e5-9446-01b96ac90295.png">

And also them in RTL (which was currently broken after we moved to the `transform-origin` fix, sigh):
<img width="168" alt="screen shot 2015-11-30 at 6 05 23 pm" src="https://cloud.githubusercontent.com/assets/1369170/11490518/1e39001e-978e-11e5-9790-2337833e3ee7.png">

And proof that giant ripples are giant:
<img width="195" alt="screen shot 2015-11-30 at 5 59 43 pm" src="https://cloud.githubusercontent.com/assets/1369170/11490526/253ca5fa-978e-11e5-9488-b5aecf824402.png">

💥 
