### PR TITLE
apply --paper-font-common-base

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -45,6 +45,9 @@ Custom property | Description | Default
 `--paper-checkbox-error-color` | Checkbox color when invalid | `--google-red-500`
 `--paper-checkbox-size` | Size of the checkbox | `18px`
 
+This element applies the mixin `--paper-font-common-base` but does not import `paper-styles/typography.html`.
+In order to apply the `Roboto` font to this element, make sure you've imported `paper-styles/typography.html`.
+
 @demo demo/index.html
 -->
 
@@ -56,6 +59,7 @@ Custom property | Description | Default
         white-space: nowrap;
         cursor: pointer;
         --calculated-paper-checkbox-size: var(--paper-checkbox-size, 18px);
+        @apply(--paper-font-common-base);
       }
 
       :host(:focus) {


### PR DESCRIPTION
Applies `--paper-font-common-base` to the host.

This is part of the effort of applying `Roboto` font to all the paper elements http://jsbin.com/mumovix/1/edit?html,output