### PR TITLE
Fixes #106: Sets line-height to 0 (except in label) and --paper-checkbox-label-spacing to 0 in tests.

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -60,6 +60,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         cursor: pointer;
         --calculated-paper-checkbox-size: var(--paper-checkbox-size, 18px);
         @apply(--paper-font-common-base);
+        line-height: 0;
       }
 
       :host(:focus) {
@@ -171,6 +172,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         vertical-align: middle;
         padding-left: var(--paper-checkbox-label-spacing, 8px);
         white-space: normal;
+        line-height: normal;
         pointer-events: none;
         color: var(--paper-checkbox-label-color, --primary-text-color);
       }

--- a/test/basic.html
+++ b/test/basic.html
@@ -18,15 +18,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../paper-checkbox.html">
+
+  <style is="custom-style">
+    paper-checkbox.no-label-spacing {
+      --paper-checkbox-label-spacing: 0;
+    }
+    paper-checkbox.giant {
+      --paper-checkbox-size: 50px;
+    }
+    paper-checkbox.tiny {
+      --paper-checkbox-size: 5px;
+    }
+  </style>
 </head>
-<style is="custom-style">
-  paper-checkbox.giant {
-    --paper-checkbox-size: 50px;
-  }
-  paper-checkbox.tiny {
-    --paper-checkbox-size: 5px;
-  }
-</style>
 <body>
 
   <test-fixture id="NoLabel">
@@ -49,9 +53,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="WithDifferentSizes">
     <template>
-      <paper-checkbox></paper-checkbox>
-      <paper-checkbox class="giant"></paper-checkbox>
-      <paper-checkbox class="tiny"></paper-checkbox>
+      <paper-checkbox class="no-label-spacing"></paper-checkbox>
+      <paper-checkbox class="no-label-spacing giant"></paper-checkbox>
+      <paper-checkbox class="no-label-spacing tiny"></paper-checkbox>
     </template>
   </test-fixture>
 
@@ -116,15 +120,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var giant = c2[1].getBoundingClientRect();
         var tiny = c2[2].getBoundingClientRect();
 
-        assert.isTrue(5 <= tiny.height);
+        assert.isTrue(5 === tiny.height);
         assert.isTrue(tiny.height < normal.height);
         assert.isTrue(normal.height < giant.height);
         assert.isTrue(giant.height <= 50);
         
-        assert.isTrue(5 <= tiny.width);
+        assert.isTrue(5 === tiny.width);
         assert.isTrue(tiny.width < normal.width);
         assert.isTrue(normal.width < giant.width);
-        assert.isTrue(giant.width <= 50);
+        assert.isTrue(giant.width === 50);
       });
     });
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -23,11 +23,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     paper-checkbox.no-label-spacing {
       --paper-checkbox-label-spacing: 0;
     }
+
     paper-checkbox.giant {
       --paper-checkbox-size: 50px;
     }
+
     paper-checkbox.tiny {
       --paper-checkbox-size: 5px;
+    }
+
+    paper-checkbox.large-line-height {
+      line-height: 3;
+    }
+
+    paper-checkbox.small-line-height {
+      line-height: 0.25;
     }
   </style>
 </head>
@@ -56,6 +66,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-checkbox class="no-label-spacing"></paper-checkbox>
       <paper-checkbox class="no-label-spacing giant"></paper-checkbox>
       <paper-checkbox class="no-label-spacing tiny"></paper-checkbox>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="WithLineHeight">
+    <template>
+      <paper-checkbox class="large-line-height">Checkbox</paper-checkbox>
+      <paper-checkbox class="small-line-height">Checkbox</paper-checkbox>
     </template>
   </test-fixture>
 
@@ -129,6 +146,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isTrue(tiny.width < normal.width);
         assert.isTrue(normal.width < giant.width);
         assert.isTrue(giant.width === 50);
+      });
+
+      suite('checkbox line-height', function() {
+        var large;
+        var small;
+
+        setup(function() {
+          var checkboxes = fixture('WithLineHeight');
+          large = checkboxes[0];
+          small = checkboxes[1];
+        });
+
+        test('checkboxes with >1 line-height have an equal height', function() {
+          var largeRect = large.getBoundingClientRect();
+          var largeStyle = getComputedStyle(large);
+
+          assert.isTrue(largeRect.height === 3 * parseFloat(largeStyle.fontSize));
+        });
+
+        test('checkbox with <1 line-height are at least 1em tall', function() {
+          var smallRect = small.getBoundingClientRect();
+          var smallStyle = getComputedStyle(small);
+
+          assert.isTrue(smallRect.height >= 1 * parseFloat(smallStyle.fontSize));
+        });
       });
     });
 


### PR DESCRIPTION
Fixes #106