### PR TITLE
remove gray tap highlight from some touch devices (e.g. chromebook pixel)

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -63,6 +63,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         --calculated-paper-checkbox-size: var(--paper-checkbox-size, 18px);
         @apply(--paper-font-common-base);
         line-height: 0;
+        -webkit-tap-highlight-color: transparent;
       }
 
       :host(:focus) {


### PR DESCRIPTION
this addresses [crbug.com/619797](https://crbug.com/619797)

/cc @notwaldorf @bicknellr @tjsavage