### PR TITLE
avoid clipping ink ripple

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -89,9 +89,11 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         position: absolute;
 
         /* Center the ripple in the checkbox by negative offsetting it by
-         * (inkWidth - rippleWidth) / 2 */
-        top: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
-        left: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
+         * (inkWidth - rippleWidth) / 2 
+         * The small initial value helps avoid floating point rounding 
+         * from clipping the ink. */
+        top: calc(-.26px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
+        left: calc(-.26px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
         width: calc(2.66 * var(--calculated-paper-checkbox-size));
         height: calc(2.66 * var(--calculated-paper-checkbox-size));
         color: var(--paper-checkbox-unchecked-ink-color, --primary-text-color);
@@ -100,7 +102,9 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       :host-context([dir="rtl"]) #ink {
-        right: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
+        /* The small initial value helps avoid floating point rounding 
+         * from clipping the ink. */
+        right: calc(.26px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
         left: auto;
       }
 


### PR DESCRIPTION
Add a small float value to alleviate rounding error clipping the ink ripple.
This issue is not seen with a 18px ripple, but is seen with a 16px ripple.
There are other values that show the issue (15px and 22px, iirc). 
I tested with sizes from 10px to 24px, which all look good now.

fixes: #130