### PR TITLE
Fixes #130: Adds `--paper-checkbox-ink-size`.

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -46,6 +46,7 @@ Custom property | Description | Default
 `--paper-checkbox-label-checked` | Mixin applied to the label when the input is checked | `{}`
 `--paper-checkbox-error-color` | Checkbox color when invalid | `--error-color`
 `--paper-checkbox-size` | Size of the checkbox | `18px`
+`--paper-checkbox-ink-size` | Size of the ripple | `48px`
 `--paper-checkbox-margin` | Margin around the checkbox container | `initial`
 `--paper-checkbox-vertical-align` | Vertical alignment of the checkbox container | `middle`
 
@@ -63,6 +64,8 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         white-space: nowrap;
         cursor: pointer;
         --calculated-paper-checkbox-size: var(--paper-checkbox-size, 18px);
+        /* -1px is a sentinel for the default and is replaced in `attached`. */
+        --calculated-paper-checkbox-ink-size: var(--paper-checkbox-ink-size, -1px);
         @apply(--paper-font-common-base);
         line-height: 0;
         -webkit-tap-highlight-color: transparent;
@@ -96,17 +99,17 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
         /* Center the ripple in the checkbox by negative offsetting it by
          * (inkWidth - rippleWidth) / 2 */
-        top: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
-        left: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
-        width: calc(2.66 * var(--calculated-paper-checkbox-size));
-        height: calc(2.66 * var(--calculated-paper-checkbox-size));
+        top: calc(0px - (var(--calculated-paper-checkbox-ink-size) - var(--calculated-paper-checkbox-size)) / 2);
+        left: calc(0px - (var(--calculated-paper-checkbox-ink-size) - var(--calculated-paper-checkbox-size)) / 2);
+        width: var(--calculated-paper-checkbox-ink-size);
+        height: var(--calculated-paper-checkbox-ink-size);
         color: var(--paper-checkbox-unchecked-ink-color, var(--primary-text-color));
         opacity: 0.6;
         pointer-events: none;
       }
 
       :host-context([dir="rtl"]) #ink {
-        right: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
+        right: calc(0px - (var(--calculated-paper-checkbox-ink-size) - var(--calculated-paper-checkbox-size)) / 2);
         left: auto;
       }
 
@@ -261,6 +264,24 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         ariaActiveAttribute: {
           type: String,
           value: 'aria-checked'
+        }
+      },
+
+      attached: function() {
+        var inkSize = this.getComputedStyleValue('--calculated-paper-checkbox-ink-size');
+        // If unset, compute and set the default `--paper-checkbox-ink-size`.
+        if (inkSize === '-1px') {
+          var checkboxSize = parseFloat(this.getComputedStyleValue('--calculated-paper-checkbox-size'));
+          var defaultInkSize = Math.floor((8 / 3) * checkboxSize);
+
+          // The checkbox and ripple need to have the same parity so that their
+          // centers align.
+          if (defaultInkSize % 2 !== checkboxSize % 2) {
+            defaultInkSize++;
+          }
+
+          this.customStyle['--paper-checkbox-ink-size'] = defaultInkSize + 'px';
+          this.updateStyles();
         }
       },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -25,12 +25,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       --paper-checkbox-label-spacing: 0;
     }
 
+    paper-checkbox.tiny {
+      --paper-checkbox-size: 5px;
+    }
+
+    paper-checkbox.medium {
+      --paper-checkbox-size: 37px;
+    }
+
     paper-checkbox.giant {
       --paper-checkbox-size: 50px;
     }
 
-    paper-checkbox.tiny {
-      --paper-checkbox-size: 5px;
+    paper-checkbox.enormous {
+      --paper-checkbox-size: 71px;
+    }
+
+    paper-checkbox.custom-ink-size {
+      --paper-checkbox-size: 25px;
+      --paper-checkbox-ink-size: 30px;
     }
 
     paper-checkbox.large-line-height {
@@ -67,6 +80,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-checkbox class="no-label-spacing"></paper-checkbox>
       <paper-checkbox class="no-label-spacing giant"></paper-checkbox>
       <paper-checkbox class="no-label-spacing tiny"></paper-checkbox>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="WithDifferentSizes2">
+    <template>
+      <paper-checkbox class="tiny"></paper-checkbox>
+      <paper-checkbox></paper-checkbox>
+      <paper-checkbox class="medium"></paper-checkbox>
+      <paper-checkbox class="giant"></paper-checkbox>
+      <paper-checkbox class="enormous"></paper-checkbox>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="CustomInkSize">
+    <template>
+      <paper-checkbox class="custom-ink-size"></paper-checkbox>
     </template>
   </test-fixture>
 
@@ -171,6 +200,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var smallStyle = getComputedStyle(small);
 
           assert.isTrue(smallRect.height >= 1 * parseFloat(smallStyle.fontSize));
+        });
+      });
+
+      suite('ink size', function() {
+        var checkboxes;
+
+        setup(function() {
+          checkboxes = fixture('WithDifferentSizes2');
+        });
+
+        test('`--paper-checkbox-ink-size` sets the ink size', function() {
+          var checkbox = fixture('CustomInkSize');
+          assert.equal(checkbox.getComputedStyleValue('--calculated-paper-checkbox-size'), '25px');
+          assert.equal(checkbox.getComputedStyleValue('--calculated-paper-checkbox-ink-size'), '30px');
+        });
+
+        test('ink sizes are near (8/3 * checkbox size) by default', function() {
+          checkboxes.forEach(function(checkbox) {
+            var size = parseFloat(checkbox.getComputedStyleValue('--calculated-paper-checkbox-size'), 10);
+            var inkSize = parseFloat(checkbox.getComputedStyleValue('--calculated-paper-checkbox-ink-size'), 10);
+            assert.approximately(inkSize / size, 8 / 3, 0.1);
+          });
+        });
+
+        test('ink sizes are integers', function() {
+          checkboxes.forEach(function(checkbox) {
+            var unparsedInkSize = checkbox.getComputedStyleValue('--calculated-paper-checkbox-ink-size');
+            var floatInkSize = parseFloat(unparsedInkSize, 10);
+            var intInkSize = parseInt(unparsedInkSize, 10);
+            assert.equal(floatInkSize, intInkSize);
+          });
+        });
+
+        test('ink size parity matches checkbox size parity (centers are aligned)', function() {
+          checkboxes.forEach(function(checkbox) {
+            var size = parseInt(checkbox.getComputedStyleValue('--calculated-paper-checkbox-size'), 10);
+            var inkSize = parseInt(checkbox.getComputedStyleValue('--calculated-paper-checkbox-ink-size'), 10);
+            assert.equal(size % 2, inkSize % 2);
+          });
         });
       });
     });


### PR DESCRIPTION
The size of the checkbox's ripple is a multiple of the checkbox's container width / height computed with CSS `calc()`. `calc()` only supports basic operators (`+`, `-`, `*`, `/`) and doesn't have any way to compute the floor or ceiling of a number because they can't be derived from these operators. Combined with paper-ripple's use of divs to create each ripple and ( browsers' behavior of rounding element bounds so that they align with pixels results in circular ripples that are sometimes noticeably clipped.

This PR adds a new CSS property, `--paper-checkbox-ink-size`, allowing the ripple size to be adjusted. This property is automatically set on `this.customStyles` in the created callback (if unset at that time) so you don't need to supply it manually.