### PR TITLE
Fixes #139: Use SVG to draw the checkmark.

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -131,25 +131,26 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
       /* checkbox checked animations */
       #checkbox.checked #checkmark {
+        opacity: 1;
         -webkit-animation: checkmark-expand 140ms ease-out forwards;
         animation: checkmark-expand 140ms ease-out forwards;
       }
 
       @-webkit-keyframes checkmark-expand {
         0% {
-          -webkit-transform: scale(0, 0) rotate(45deg);
+          -webkit-transform: scale(0);
         }
         100% {
-          -webkit-transform: scale(1, 1) rotate(45deg);
+          -webkit-transform: scale(1);
         }
       }
 
       @keyframes checkmark-expand {
         0% {
-          transform: scale(0, 0) rotate(45deg);
+          transform: scale(0);
         }
         100% {
-          transform: scale(1, 1) rotate(45deg);
+          transform: scale(1);
         }
       }
 
@@ -158,24 +159,11 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         border-color: var(--paper-checkbox-checked-color, var(--primary-color));
       }
 
-      #checkmark {
-        position: absolute;
-        width: 36%;
-        height: 70%;
-        border-style: solid;
-        border-top: none;
-        border-left: none;
-        border-right-width: calc(2/15 * var(--calculated-paper-checkbox-size));
-        border-bottom-width: calc(2/15 * var(--calculated-paper-checkbox-size));
-        border-color: var(--paper-checkbox-checkmark-color, white);
-        -webkit-transform-origin: 97% 86%;
-        transform-origin: 97% 86%;
-        box-sizing: content-box; /* protect against page-level box-sizing */
-      }
-
-      :host-context([dir="rtl"]) #checkmark {
-        -webkit-transform-origin: 50% 14%;
-        transform-origin: 50% 14%;
+      #checkbox #checkmark {
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        stroke: var(--paper-checkbox-checkmark-color, white);
       }
 
       /* label */
@@ -228,7 +216,9 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
     <div id="checkboxContainer">
       <div id="checkbox" class$="[[_computeCheckboxClass(checked, invalid)]]">
-        <div id="checkmark" class$="[[_computeCheckmarkClass(checked)]]"></div>
+        <svg id="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
+          <path d="M 1 6.5 l 4 4 l 8 -8" fill="transparent" stroke-width="1.75" />
+        </svg>
       </div>
     </div>
 
@@ -299,10 +289,6 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
           className += 'invalid';
         }
         return className;
-      },
-
-      _computeCheckmarkClass: function(checked) {
-        return checked ? '' : 'hidden';
       },
 
       // create ripple inside the checkboxContainer

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -113,7 +113,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         left: auto;
       }
 
-      #ink[checked] {
+      :host([checked]) #ink {
         color: var(--paper-checkbox-checked-ink-color, var(--primary-color));
       }
 
@@ -130,7 +130,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       /* checkbox checked animations */
-      #checkbox.checked #checkmark {
+      :host([checked]) #checkbox #checkmark {
         opacity: 1;
         -webkit-animation: checkmark-expand 140ms ease-out forwards;
         animation: checkmark-expand 140ms ease-out forwards;
@@ -154,7 +154,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         }
       }
 
-      #checkbox.checked {
+      :host([checked]) #checkbox {
         background-color: var(--paper-checkbox-checked-color, var(--primary-color));
         border-color: var(--paper-checkbox-checked-color, var(--primary-color));
       }
@@ -215,13 +215,13 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       /* invalid state */
-      #checkbox.invalid:not(.checked) {
+      :host([checked]) #checkbox.invalid {
         border-color: var(--paper-checkbox-error-color, var(--error-color));
       }
     </style>
 
     <div id="checkboxContainer">
-      <div id="checkbox" class$="[[_computeCheckboxClass(checked, invalid)]]">
+      <div id="checkbox" class$="[[_computeCheckboxClass(invalid)]]">
         <svg id="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 14 14">
           <path d="M10 17l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path>
         </svg>
@@ -293,15 +293,8 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         });
       },
 
-      _computeCheckboxClass: function(checked, invalid) {
-        var className = '';
-        if (checked) {
-          className += 'checked ';
-        }
-        if (invalid) {
-          className += 'invalid';
-        }
-        return className;
+      _computeCheckboxClass: function(invalid) {
+        return invalid ? 'invalid' : '';
       },
 
       // create ripple inside the checkboxContainer

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -163,7 +163,8 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         width: 100%;
         height: 100%;
         opacity: 0;
-        stroke: var(--paper-checkbox-checkmark-color, white);
+        stroke: rgba(0, 0, 0, 0);
+        fill: var(--paper-checkbox-checkmark-color, white);
       }
 
       /* label */
@@ -216,8 +217,8 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
     <div id="checkboxContainer">
       <div id="checkbox" class$="[[_computeCheckboxClass(checked, invalid)]]">
-        <svg id="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
-          <path d="M 1 6.5 l 4 4 l 8 -8" fill="transparent" stroke-width="1.75" />
+        <svg id="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 14 14">
+          <path d="M10 17l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path>
         </svg>
       </div>
     </div>

--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -94,6 +94,12 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         background-color: var(--paper-checkbox-unchecked-background-color, transparent);
       }
 
+      svg {
+        /* This transform causes Firefox to move the svg element to a pixel
+        boundary. */
+        transform: translate(0px, 0px);
+      }
+
       #ink {
         position: absolute;
 
@@ -118,19 +124,15 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #checkbox {
-        position: relative;
-        box-sizing: border-box;
-        height: 100%;
-        border: solid 2px;
-        border-color: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
-        border-radius: 2px;
+        fill: none;
+        stroke: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
         pointer-events: none;
         -webkit-transition: background-color 140ms, border-color 140ms;
         transition: background-color 140ms, border-color 140ms;
       }
 
       /* checkbox checked animations */
-      :host([checked]) #checkbox #checkmark {
+      :host([checked]) #checkmark {
         opacity: 1;
         -webkit-animation: checkmark-expand 140ms ease-out forwards;
         animation: checkmark-expand 140ms ease-out forwards;
@@ -155,16 +157,17 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       :host([checked]) #checkbox {
-        background-color: var(--paper-checkbox-checked-color, var(--primary-color));
-        border-color: var(--paper-checkbox-checked-color, var(--primary-color));
+        fill: var(--paper-checkbox-checked-color, var(--primary-color));
+        stroke: var(--paper-checkbox-checked-color, var(--primary-color));
       }
 
-      #checkbox #checkmark {
+      #checkmark {
         width: 100%;
         height: 100%;
         opacity: 0;
         stroke: rgba(0, 0, 0, 0);
         fill: var(--paper-checkbox-checkmark-color, white);
+        transform-origin: center;
       }
 
       #checkmark:dir(rtl) {
@@ -202,11 +205,11 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
       :host([disabled]) #checkbox {
         opacity: 0.5;
-        border-color: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
+        stroke: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
       }
 
       :host([disabled][checked]) #checkbox {
-        background-color: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
+        fill: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
         opacity: 0.5;
       }
 
@@ -215,17 +218,16 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       /* invalid state */
-      :host([checked]) #checkbox.invalid {
-        border-color: var(--paper-checkbox-error-color, var(--error-color));
+      :host([invalid]:not([checked])) #checkbox {
+        stroke: var(--paper-checkbox-error-color, var(--error-color));
       }
     </style>
 
     <div id="checkboxContainer">
-      <div id="checkbox" class$="[[_computeCheckboxClass(invalid)]]">
-        <svg id="checkmark" xmlns="http://www.w3.org/2000/svg" viewBox="5 5 14 14">
-          <path d="M10 17l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path>
-        </svg>
-      </div>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+        <rect id="checkbox" x="1" y="1" width="16" height="16" rx="1" ry="1" stroke-width="2"></rect>
+        <path id="checkmark" d="M7 14l-5-5 1.41-1.41L7 11.17l7.59-7.59L16 5l-9 9z"></path>
+      </svg>
     </div>
 
     <div id="checkboxLabel"><slot></slot></div>
@@ -291,10 +293,6 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
             });
           }
         });
-      },
-
-      _computeCheckboxClass: function(invalid) {
-        return invalid ? 'invalid' : '';
       },
 
       // create ripple inside the checkboxContainer


### PR DESCRIPTION
Go to either demo below and resize the window to see the difference:

before: http://jsbin.com/fepide/1/edit?html,output
![screen shot 2016-07-20 at 17 46 17](https://cloud.githubusercontent.com/assets/406614/17007978/eca672f4-4ea1-11e6-8fb8-2336b63f5761.png)

after: http://jsbin.com/lisubu/1/edit?html,output
![screen shot 2016-07-20 at 17 46 24](https://cloud.githubusercontent.com/assets/406614/17007980/f09fecc8-4ea1-11e6-97cc-fae2488b1963.png)

(Fixes #139.)
