### PR TITLE
Correct var() fallbacks

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -100,7 +100,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         left: calc(0px - (2.66 * var(--calculated-paper-checkbox-size) - var(--calculated-paper-checkbox-size)) / 2);
         width: calc(2.66 * var(--calculated-paper-checkbox-size));
         height: calc(2.66 * var(--calculated-paper-checkbox-size));
-        color: var(--paper-checkbox-unchecked-ink-color, --primary-text-color);
+        color: var(--paper-checkbox-unchecked-ink-color, var(--primary-text-color));
         opacity: 0.6;
         pointer-events: none;
       }
@@ -111,7 +111,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #ink[checked] {
-        color: var(--paper-checkbox-checked-ink-color, --primary-color);
+        color: var(--paper-checkbox-checked-ink-color, var(--primary-color));
       }
 
       #checkbox {
@@ -119,7 +119,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         box-sizing: border-box;
         height: 100%;
         border: solid 2px;
-        border-color: var(--paper-checkbox-unchecked-color, --primary-text-color);
+        border-color: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
         border-radius: 2px;
         pointer-events: none;
         -webkit-transition: background-color 140ms, border-color 140ms;
@@ -151,8 +151,8 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       #checkbox.checked {
-        background-color: var(--paper-checkbox-checked-color, --primary-color);
-        border-color: var(--paper-checkbox-checked-color, --primary-color);
+        background-color: var(--paper-checkbox-checked-color, var(--primary-color));
+        border-color: var(--paper-checkbox-checked-color, var(--primary-color));
       }
 
       #checkmark {
@@ -183,12 +183,12 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         padding-left: var(--paper-checkbox-label-spacing, 8px);
         white-space: normal;
         line-height: normal;
-        color: var(--paper-checkbox-label-color, --primary-text-color);
+        color: var(--paper-checkbox-label-color, var(--primary-text-color));
         @apply(--paper-checkbox-label);
       }
 
       :host([checked]) #checkboxLabel {
-        color: var(--paper-checkbox-label-checked-color, --paper-checkbox-label-color);
+        color: var(--paper-checkbox-label-checked-color, var(--paper-checkbox-label-color, var(--primary-text-color)));
         @apply(--paper-checkbox-label-checked);
       }
 
@@ -205,11 +205,11 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
       :host([disabled]) #checkbox {
         opacity: 0.5;
-        border-color: var(--paper-checkbox-unchecked-color, --primary-text-color);
+        border-color: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
       }
 
       :host([disabled][checked]) #checkbox {
-        background-color: var(--paper-checkbox-unchecked-color, --primary-text-color);
+        background-color: var(--paper-checkbox-unchecked-color, var(--primary-text-color));
         opacity: 0.5;
       }
 
@@ -219,7 +219,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
       /* invalid state */
       #checkbox.invalid:not(.checked) {
-        border-color: var(--paper-checkbox-error-color, --error-color);
+        border-color: var(--paper-checkbox-error-color, var(--error-color));
       }
     </style>
 


### PR DESCRIPTION
`:host([checked]) #checkboxLabel` color should fallback to `--primary-text-color` if neither label color is set.

Fixes https://github.com/Polymer/polymer/issues/3836#issuecomment-237915421