### PR TITLE
Fixes #103 by increasing margin to allow wrapping inside the paper-checkbox

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -180,6 +180,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
       /* label */
       #checkboxLabel {
+        -webkit-margin-end: var(--paper-checkbox-size, 18px);
         position: relative;
         display: inline-block;
         vertical-align: middle;


### PR DESCRIPTION
https://github.com/PolymerElements/paper-checkbox/issues/103

The contents of #checkboxLabel are spilling out of the paper-checkbox by the size of the checkbox.
Adding margin on the right that's the same size will keep the wrapping contained.