### PR TITLE
Fixes #103 Add end margin to checkbox for wrapping

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -180,6 +180,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
 
       /* label */
       #checkboxLabel {
+        -webkit-margin-end: var(--calculated-paper-checkbox-size);
         position: relative;
         display: inline-block;
         vertical-align: middle;


### PR DESCRIPTION
The label doesn't take into account the width of the checkbox. This change adds a margin to the right so that the text doesn't spill over.