### PR TITLE
Fixes #103 Remove width of checkbox from label

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -187,6 +187,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         white-space: normal;
         line-height: normal;
         color: var(--paper-checkbox-label-color, var(--primary-text-color));
+        width: calc(100% - var(--paper-checkbox-size) - var(--paper-checkbox-label-spacing));
         @apply(--paper-checkbox-label);
       }
 


### PR DESCRIPTION
The label was spilling over by the width of the checkbox and the spacing. This PR removes the spillage.