### PR TITLE
#170 Ensure checked has a default value of false if not set

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -264,6 +264,17 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         ariaActiveAttribute: {
           type: String,
           value: 'aria-checked'
+        },
+
+        /**
+         * @attribute checked
+         * @type Boolean
+         */
+        checked: {
+          type: Boolean,
+          value: function() {
+            this.checked = this.checked | false;
+          }
         }
       },
 


### PR DESCRIPTION
There is a known bug where when checked is bound to in a template value it's default value when unset is 'undefined' which results in the essential _compute functions not being called. Thus the hidden class (most importantly) is not defined and the default checkbox remains visible within the paper-checkbox location resulting in very bad UX.

This is probably a very inefficient method but.... it works. And doesn't loop so it's a start at least. And because it doesn't rely on passing itself into a computed function, it is still called when it's undefined and thus solves the primary problem indicated in #170