### PR TITLE
Moved validation styling to component scope.

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -221,13 +221,13 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
 
       /* invalid state */
-      #checkbox.invalid:not(.checked) {
+      :host([invalid]) #checkbox:not(.checked) {
         border-color: var(--paper-checkbox-error-color, var(--error-color));
       }
     </style>
 
     <div id="checkboxContainer">
-      <div id="checkbox" class$="[[_computeCheckboxClass(checked, invalid)]]">
+      <div id="checkbox" class$="[[_computeCheckboxClass(checked)]]">
         <div id="checkmark" class$="[[_computeCheckmarkClass(checked)]]"></div>
       </div>
     </div>
@@ -285,15 +285,8 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         }
       },
 
-      _computeCheckboxClass: function(checked, invalid) {
-        var className = '';
-        if (checked) {
-          className += 'checked ';
-        }
-        if (invalid) {
-          className += 'invalid';
-        }
-        return className;
+      _computeCheckboxClass: function(checked) {
+        return checked ? 'checked' : '';
       },
 
       _computeCheckmarkClass: function(checked) {


### PR DESCRIPTION
Fixes #140 and maybe a few others.

## General problem:
Due to internal dirty check of [polymer notification logic](https://github.com/Polymer/polymer/blob/1.x/src/lib/bind/effects.html#L141) that prevents notification of computed methods with more than one argument in case when changed value from 'any' to undefined;

## Fix steps: 
* Removed validation class setup from the checkbox div (now computed property will hold only one argument). 
* Changed validation styling to rely on iron-validatable-behavior in the first place.