### PR TITLE
Give ability to determine selected checkbox

### DIFF
--- a/paper-checkbox.html
+++ b/paper-checkbox.html
@@ -226,7 +226,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       }
     </style>
 
-    <div id="checkboxContainer">
+    <div id="checkboxContainer" type$="[[type]]>
       <div id="checkbox" class$="[[_computeCheckboxClass(checked, invalid)]]">
         <div id="checkmark" class$="[[_computeCheckmarkClass(checked)]]"></div>
       </div>


### PR DESCRIPTION
Often there is a use case where we need uniquely identify which exactly checkbox was pressed.

So actually the issue is that tap target returns checkboxContainer div.
And i can't determine whether the row was selected or column value changed.

Consider example for grid like inline editing where we have a lot of checkboxes.
![checkbox-issue](https://user-images.githubusercontent.com/1307140/35314748-da7c488c-00d0-11e8-88f4-98dfacc855e0.png)
